### PR TITLE
Only send the effectively read bytes instead of the entire buffer (CSharp only)

### DIFF
--- a/C-Sharp/ICAP/ICAP.cs
+++ b/C-Sharp/ICAP/ICAP.cs
@@ -178,8 +178,8 @@ namespace ICAPNameSpace
                     while ((n = fileStream.Read(buffer, 0, stdSendLength)) > 0)
                     {
                         offset += n;  // offset for next reading
-                        sender.Send(Encoding.ASCII.GetBytes(buffer.Length.ToString("X") + "\r\n"));
-                        sender.Send(buffer);
+                        sender.Send(Encoding.ASCII.GetBytes(n.ToString("X") + "\r\n"));
+                        sender.Send(buffer, 0, n, SocketFlags.None);
                         sender.Send(Encoding.ASCII.GetBytes("\r\n"));
                     }
                     //Closing file transfer.


### PR DESCRIPTION
Fixes issue https://github.com/Baekalfen/ICAP-avscan/issues/23 for the C# ICAP Client.
Fix for the java client is still tbd.